### PR TITLE
Ensure build artifacts are cleaned out

### DIFF
--- a/Dockerfile.erb
+++ b/Dockerfile.erb
@@ -3,9 +3,12 @@ FROM quay.io/<%= ENV.fetch('FROM') %>
 ENV RUBY_VERSION <%= ENV.fetch('RUBY_VERSION') %>
 ENV RUBY_SHA1SUM <%= ENV.fetch('RUBY_SHA1SUM') %>
 
-RUN apt-get update \
+RUN BUILD_DIR="/tmp/ruby-build" \
+ && apt-get update \
  && apt-get -y install wget build-essential zlib1g-dev libssl-dev \
-    libreadline6-dev libyaml-dev && cd /tmp \
+    libreadline6-dev libyaml-dev \
+ && mkdir -p "$BUILD_DIR" \
+ && cd "$BUILD_DIR" \
  && wget -q "http://cache.ruby-lang.org/pub/ruby/ruby-${RUBY_VERSION}.tar.gz" \
  && echo "${RUBY_SHA1SUM}  ruby-${RUBY_VERSION}.tar.gz" | sha1sum -c - \
  && tar xzf "ruby-${RUBY_VERSION}.tar.gz" \
@@ -13,8 +16,9 @@ RUN apt-get update \
  && ./configure --enable-shared --prefix=/usr \
  && make \
  && make install \
- && cd .. \
- && rm -rf "ruby-${RUBY_VERSION}"{,.tar.gz}
+ && cd / \
+ && rm -r "$BUILD_DIR"
+
 RUN gem install bundler
 
 ADD test /tmp/test

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -o errexit
+set -o nounset
+
+# Test Ruby image for its size. It's preferable to do so
+# here rather than in a BATS test in case a customer is running
+# out tests after adding to this image.
+
+IMG="$REGISTRY/$REPOSITORY:$TAG"
+
+
+echo "Checking image size"
+
+MAX_SIZE=600000  # 600M
+docker run --rm -it "$IMG" bash -c "[[ \"\$(du -d0 / 2>/dev/null | awk '{print \$1; print > \"/dev/stderr\"}')\" -lt \"$MAX_SIZE\" ]]"
+
+
+echo "Test OK"


### PR DESCRIPTION
I probably tried to do something too cute for my own good with `rm -rf "ruby-${RUBY_VERSION}"{,.tar.gz}`. I'm not actually sure what that fails (but I'm probably simply missing something obvious).

Either way, this PR ensures we properly clean out the Ruby build artifact and keep the image to a reasonable size. I also added a test that checks the image size is < 600M, but note that this is the *uncompressed* size (the one with the build artifacts approaches 1G).

I haven't tested all Ruby versions against this (arbitrary) limit, but Travis will do that for us now!

--

Commit message follows:

Not sure why "ruby-${RUBY_VERSION}"{,.tar.gz} didn't work here, but it
clearly didn't, which added 300M of uncached useless fat to the image.

Added a test to ensure the image stays under 600M (it currently should
be ~500M), which should be a high watermark and an indicator that
something went wrong.