### PR TITLE
Security update: upgrade RubyGems to ensure >= 2.6.13

### DIFF
--- a/Dockerfile.erb
+++ b/Dockerfile.erb
@@ -19,6 +19,7 @@ RUN BUILD_DIR="/tmp/ruby-build" \
  && cd / \
  && rm -r "$BUILD_DIR"
 
+RUN gem update --system
 RUN gem install bundler
 
 ADD test /tmp/test

--- a/test/ruby.bats
+++ b/test/ruby.bats
@@ -25,3 +25,8 @@
   # 1.6 is not affected
   dpkg -s libyaml-dev | grep -E "Version: 0.1.(4-[2-9]|6-[0-9])"
 }
+
+@test "It should install RubyGems >= 2.6.13" {
+  # See http://blog.rubygems.org/2017/08/27/2.6.13-released.html
+  ruby -e 'p Gem::Version.new(Gem::VERSION) >= Gem::Version.new("2.6.13")' | grep true
+}


### PR DESCRIPTION
@krallin : The newer (patched) version of RubyGems hasn't yet been included in the official Ruby releases, so I'm just `gem update --system` and checking for the required version in Bats tests. Please let me know if you want me to make any changes!