### PR TITLE
We don't want Make to cache TAG/Dockerfile.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,5 +124,5 @@ $(TAG):
 	mkdir -p "$(TAG)"
 
 
-.PHONY: push test build
+.PHONY: push test build $(TAG)/Dockerfile
 .DEFAULT_GOAL := test


### PR DESCRIPTION
We use Make to track *how* we build those dependencies, but we don't need to use Make to track their last changes.