### PR TITLE
Ensure tzdata is installed, since it's required by common tzinfo gem

### DIFF
--- a/Dockerfile.erb
+++ b/Dockerfile.erb
@@ -6,7 +6,7 @@ ENV RUBY_SHA1SUM <%= ENV.fetch('RUBY_SHA1SUM') %>
 RUN BUILD_DIR="/tmp/ruby-build" \
  && apt-get update \
  && apt-get -y install wget build-essential zlib1g-dev libssl-dev \
-    libreadline6-dev libyaml-dev \
+    libreadline6-dev libyaml-dev tzdata \
  && mkdir -p "$BUILD_DIR" \
  && cd "$BUILD_DIR" \
  && wget -q "http://cache.ruby-lang.org/pub/ruby/ruby-${RUBY_VERSION}.tar.gz" \

--- a/test/ruby.bats
+++ b/test/ruby.bats
@@ -30,3 +30,7 @@
   # See http://blog.rubygems.org/2017/08/27/2.6.13-released.html
   ruby -e 'p Gem::Version.new(Gem::VERSION) >= Gem::Version.new("2.6.13")' | grep true
 }
+
+@test "It should install tzdata" {
+  dpkg -l tzdata
+}


### PR DESCRIPTION
Without the tzdata system package installed, loading the common `tzinfo` gem will fail with:

```
 TZInfo::DataSourceNotFound: tzinfo-data is not present. Please add gem 'tzinfo-data' to your Gemfile and run bundle install
 [...]
 TZInfo::ZoneinfoDirectoryNotFound: None of the paths included in TZInfo::ZoneinfoDataSource.search_path are valid zoneinfo directories.
```

Of the 4 base images used in our `aptible/ruby` build matrix, i.e.:

* `aptible/ubuntu:12.04`
* `aptible/ubuntu:16.04`
* `aptible/debian:wheezy`
* `aptible/debian:jessie`

The tzdata APT package is installed in all but `aptible/ubuntu:16.04`. We _could_ address this in that particular base image, but to prevent future regressions I've instead (re-)installed tzdata here and added a test. Please LMK if you prefer a different approach, @krallin .