### PR TITLE
Update ruby 2.5 and 2.6 patches

### DIFF
--- a/2.5/config.mk
+++ b/2.5/config.mk
@@ -1,6 +1,6 @@
 export RUBY_MAJOR_MINOR = 2.5
-export RUBY_PATCH = 3
+export RUBY_PATCH = 5
 
-export RUBY_SHA1SUM = f919a9fbcdb7abecd887157b49833663c5c15fda
+export RUBY_SHA1SUM = e6a063728950762925108abbdbf68968ec1ab5bb
 
 export BUNDLER_VERSION = 2.0

--- a/2.6/config.mk
+++ b/2.6/config.mk
@@ -1,5 +1,6 @@
 export RUBY_MAJOR_MINOR = 2.6
-export RUBY_PATCH = 1
-export RUBY_SHA1SUM = 416842bb5b4ca655610df1f0389b6e21d25154f8
+export RUBY_PATCH = 2
+
+export RUBY_SHA1SUM = 44c6634a41f63ebdc1f3ce6ddcf48a4766bb4df7
 
 export BUNDLER_VERSION = 2.0

--- a/README.md
+++ b/README.md
@@ -12,15 +12,15 @@ The Ruby programming language, on Docker.
 
 ## Available Tags
 
-* `latest`: Currently Ruby 2.6.1 (don't depend on this tag: it will change over time).
+* `latest`: Currently Ruby 2.6.2 (don't depend on this tag: it will change over time).
 * `1.9.3-ubuntu-16.04` (aliased as `1.9.3`): Ruby 1.9.3-p547
 * `2.0.0-ubuntu-16.04` (aliased as `2.0.0`): Ruby 2.0.0-p648
 * `2.1-ubuntu-16.04`   (aliased as `2.1`):   Ruby 2.1.10
 * `2.2-ubuntu-16.04`   (aliased as `2.2`):   Ruby 2.2.10
 * `2.3-ubuntu-16.04`   (aliased as `2.3`):   Ruby 2.3.8
 * `2.4-ubuntu-16.04`   (aliased as `2.4`):   Ruby 2.4.5
-* `2.5-ubuntu-16.04`   (aliased as `2.5`):   Ruby 2.5.3
-* `2.6-ubuntu-16.04`   (aliased as `2.6`):   Ruby 2.6.1
+* `2.5-ubuntu-16.04`   (aliased as `2.5`):   Ruby 2.5.5
+* `2.6-ubuntu-16.04`   (aliased as `2.6`):   Ruby 2.6.2
 
 As the name implies, those images are based on Ubuntu. You can use the Debian
 variants (which are slightly lighter) using the following tags:


### PR DESCRIPTION
https://www.ruby-lang.org/en/news/2019/03/13/ruby-2-6-2-released/
https://www.ruby-lang.org/en/news/2019/03/13/ruby-2-5-4-released/