### PR TITLE
Wheezy is EOL and now deprecated.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,15 +24,6 @@ env:
     - RUBY_TAG=2.5 FROM_OS=ubuntu FROM_TAG=16.04
     - RUBY_TAG=2.6 FROM_OS=ubuntu FROM_TAG=16.04
 
-    - RUBY_TAG=1.9.3 FROM_OS=debian FROM_TAG=wheezy
-    - RUBY_TAG=2.0.0 FROM_OS=debian FROM_TAG=wheezy
-    - RUBY_TAG=2.1 FROM_OS=debian FROM_TAG=wheezy
-    - RUBY_TAG=2.2 FROM_OS=debian FROM_TAG=wheezy
-    - RUBY_TAG=2.3 FROM_OS=debian FROM_TAG=wheezy
-    - RUBY_TAG=2.4 FROM_OS=debian FROM_TAG=wheezy
-    - RUBY_TAG=2.5 FROM_OS=debian FROM_TAG=wheezy
-    - RUBY_TAG=2.6 FROM_OS=debian FROM_TAG=wheezy
-
     - RUBY_TAG=1.9.3 FROM_OS=debian FROM_TAG=jessie
     - RUBY_TAG=2.0.0 FROM_OS=debian FROM_TAG=jessie
     - RUBY_TAG=2.1 FROM_OS=debian FROM_TAG=jessie


### PR DESCRIPTION
I've manually pushed the ruby:*-debian-wheezy images with the following configuration, to return a friendlier message for anyone attempting to build an App image from the wheezy-based images:

```
FROM debian:wheezy

ONBUILD RUN echo "All images based on Debian Wheezy are now deprecated. Please use a Ruby tag based on Debian Jessie instead." && false
```