### PR TITLE
Version bump for 2.6

### DIFF
--- a/2.6/config.mk
+++ b/2.6/config.mk
@@ -1,6 +1,6 @@
 export RUBY_MAJOR_MINOR = 2.6
-export RUBY_PATCH = 2
+export RUBY_PATCH = 3
 
-export RUBY_SHA1SUM = 44c6634a41f63ebdc1f3ce6ddcf48a4766bb4df7
+export RUBY_SHA1SUM = 2347ed6ca5490a104ebd5684d2b9b5eefa6cd33c
 
 export BUNDLER_VERSION = 2.0


### PR DESCRIPTION
>This release adds support for New Japanese Era “令和” (Reiwa). It updates the Unicode version to 12.1 beta (#15195), and updates date library (#15742).

>This release also includes some bug fixes.

https://www.ruby-lang.org/en/news/2019/04/17/ruby-2-6-3-released/