### PR TITLE
Add support for Ruby build dependencies (e.g. `jemalloc`) + tagging

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,9 @@ env:
     - RUBY_TAG=2.3 FROM_OS=ubuntu FROM_TAG=16.04
     - RUBY_TAG=2.4 FROM_OS=ubuntu FROM_TAG=16.04
     - RUBY_TAG=2.5 FROM_OS=ubuntu FROM_TAG=16.04
+    - RUBY_TAG=2.5 FROM_OS=ubuntu FROM_TAG=16.04 RUBY_TAG_SUFFIX="jemalloc" RUBY_CONFIG_OPTS="--with-jemalloc" RUBY_BUILD_DEPENDENCIES="libjemalloc-dev"
     - RUBY_TAG=2.6 FROM_OS=ubuntu FROM_TAG=16.04
+    - RUBY_TAG=2.6 FROM_OS=ubuntu FROM_TAG=16.04 RUBY_TAG_SUFFIX="jemalloc" RUBY_CONFIG_OPTS="--with-jemalloc" RUBY_BUILD_DEPENDENCIES="libjemalloc-dev"
 
     - RUBY_TAG=1.9.3 FROM_OS=debian FROM_TAG=jessie
     - RUBY_TAG=2.0.0 FROM_OS=debian FROM_TAG=jessie

--- a/Dockerfile.erb
+++ b/Dockerfile.erb
@@ -4,18 +4,20 @@ ENV RUBY_MAJOR_MINOR <%= ENV.fetch('RUBY_MAJOR_MINOR') %>
 ENV RUBY_PATCH <%= ENV.fetch('RUBY_PATCH') %>
 ENV RUBY_VERSION <%= ENV.fetch('RUBY_MAJOR_MINOR') %>.<%= ENV.fetch('RUBY_PATCH') %>
 ENV RUBY_SHA1SUM <%= ENV.fetch('RUBY_SHA1SUM') %>
+ENV RUBY_BUILD_DEPENDENCIES="<%= ENV['RUBY_BUILD_DEPENDENCIES'] %>"
+ENV RUBY_CONFIG_OPTS="<%= ENV['RUBY_CONFIG_OPTS'] %>"
 
 RUN BUILD_DIR="/tmp/ruby-build" \
  && apt-get update \
  && apt-get -y install wget build-essential zlib1g-dev libssl-dev \
-    libreadline6-dev libyaml-dev tzdata \
+    libreadline6-dev libyaml-dev tzdata ${RUBY_BUILD_DEPENDENCIES} \
  && mkdir -p "$BUILD_DIR" \
  && cd "$BUILD_DIR" \
  && wget -q "http://cache.ruby-lang.org/pub/ruby/${RUBY_MAJOR_MINOR}/ruby-${RUBY_VERSION}.tar.gz" \
  && echo "${RUBY_SHA1SUM}  ruby-${RUBY_VERSION}.tar.gz" | sha1sum -c - \
  && tar xzf "ruby-${RUBY_VERSION}.tar.gz" \
  && cd "ruby-${RUBY_VERSION}" \
- && ./configure --enable-shared --prefix=/usr \
+ && ./configure --enable-shared --prefix=/usr ${RUBY_CONFIG_OPTS} \
  && make \
  && make install \
  && cd / \

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ for further information.
 * `2.1-ubuntu-16.04`   (aliased as `2.1`):   Ruby 2.1.10  (EOL March 31, 2017)
 * `2.2-ubuntu-16.04`   (aliased as `2.2`):   Ruby 2.2.10  (EOL March 31, 2018)
 * `2.3-ubuntu-16.04`   (aliased as `2.3`):   Ruby 2.3.8  (EOL March 31, 2019)
-* `2.4-ubuntu-16.04`   (aliased as `2.4`):   Ruby 2.4.6
+* `2.4-ubuntu-16.04`   (aliased as `2.4`):   Ruby 2.4.6  (EOL March 31, 2020)
 * `2.5-ubuntu-16.04`   (aliased as `2.5`):   Ruby 2.5.5
 * `2.6-ubuntu-16.04`   (aliased as `2.6`):   Ruby 2.6.2
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ for further information.
 
 ## Available Tags
 
-* `latest`: Currently Ruby 2.6.2 (don't depend on this tag: it will change over time).
+* `latest`: Currently Ruby 2.6.3 (don't depend on this tag: it will change over time).
 * `1.9.3-ubuntu-16.04` (aliased as `1.9.3`): Ruby 1.9.3-p547  (EOL February 23, 2015)
 * `2.0.0-ubuntu-16.04` (aliased as `2.0.0`): Ruby 2.0.0-p648  (EOL February 24, 2016)
 * `2.1-ubuntu-16.04`   (aliased as `2.1`):   Ruby 2.1.10  (EOL March 31, 2017)
@@ -29,7 +29,7 @@ for further information.
 * `2.3-ubuntu-16.04`   (aliased as `2.3`):   Ruby 2.3.8  (EOL March 31, 2019)
 * `2.4-ubuntu-16.04`   (aliased as `2.4`):   Ruby 2.4.6  (EOL March 31, 2020)
 * `2.5-ubuntu-16.04`   (aliased as `2.5`):   Ruby 2.5.5
-* `2.6-ubuntu-16.04`   (aliased as `2.6`):   Ruby 2.6.2
+* `2.6-ubuntu-16.04`   (aliased as `2.6`):   Ruby 2.6.3
 
 As the name implies, those images are based on Ubuntu. You can use the Debian
 variants (which are slightly lighter) using the following tags:

--- a/README.md
+++ b/README.md
@@ -29,7 +29,9 @@ for further information.
 * `2.3-ubuntu-16.04`   (aliased as `2.3`):   Ruby 2.3.8  (EOL March 31, 2019)
 * `2.4-ubuntu-16.04`   (aliased as `2.4`):   Ruby 2.4.6  (EOL March 31, 2020)
 * `2.5-ubuntu-16.04`   (aliased as `2.5`):   Ruby 2.5.5
+* `2.5-jemalloc-ubuntu-16.04`:               Ruby 2.5.5, built with [jemalloc](http://jemalloc.net/)
 * `2.6-ubuntu-16.04`   (aliased as `2.6`):   Ruby 2.6.3
+* `2.6-jemalloc-ubuntu-16.04`:               Ruby 2.6.3, built with [jemalloc](http://jemalloc.net/)
 
 As the name implies, those images are based on Ubuntu. You can use the Debian
 variants (which are slightly lighter) using the following tags:

--- a/config.mk
+++ b/config.mk
@@ -1,7 +1,13 @@
 REGISTRY = quay.io
 REPOSITORY = aptible/ruby
 
+# Conditionally inject Ruby tag suffix, if present
+ifdef RUBY_TAG_SUFFIX
+export TAG = $(RUBY_TAG)-$(RUBY_TAG_SUFFIX)-$(FROM_OS)-$(FROM_TAG)
+else
 export TAG = $(RUBY_TAG)-$(FROM_OS)-$(FROM_TAG)
+endif
+
 export FROM = aptible/$(FROM_OS):$(FROM_TAG)
 
 # Now, we have to figure out aliases.

--- a/config.mk
+++ b/config.mk
@@ -13,12 +13,14 @@ export FROM = aptible/$(FROM_OS):$(FROM_TAG)
 # Now, we have to figure out aliases.
 PUSH_TAGS = $(TAG) ruby-$(TAG)
 
-ifeq "$(FROM_OS):$(FROM_TAG)" "ubuntu:16.04"
+# `RUBY_TAG_SUFFIX` included to ensure suffixed Ruby builds aren't set as default
+ifeq "$(FROM_OS):$(FROM_TAG)$(RUBY_TAG_SUFFIX)" "ubuntu:16.04"
 # Ubuntu 16.04 gets the default tag and the default Ubuntu tag.
 PUSH_TAGS += $(RUBY_TAG) $(RUBY_TAG)-ubuntu ruby-$(RUBY_TAG)-ubuntu
 endif
 
-ifeq "$(FROM_OS):$(FROM_TAG)" "debian:jessie"
+# `RUBY_TAG_SUFFIX` included to ensure suffixed Ruby builds aren't set as default
+ifeq "$(FROM_OS):$(FROM_TAG)$(RUBY_TAG_SUFFIX)" "debian:jessie"
 # Debian Jessie gets the default Debian tag.
 PUSH_TAGS += $(RUBY_TAG)-debian ruby-$(RUBY_TAG)-debian
 endif

--- a/test/ruby.bats
+++ b/test/ruby.bats
@@ -34,3 +34,13 @@
 @test "It should install tzdata" {
   dpkg -l tzdata
 }
+
+@test "It should be configured with jemalloc if flagged" {
+  if ! [[ ${RUBY_CONFIG_OPTS} =~ .*\-\-with\-jemalloc.* ]]; then
+    skip "'--with-jemalloc' flag not present"
+  fi
+
+  # "LIBS"      : Ruby version <= 2.5
+  # "MAINLIBS"  : Ruby version > 2.5
+  ruby -r rbconfig -e "puts RbConfig::CONFIG.slice('LIBS', 'MAINLIBS')" | grep "\-ljemalloc"
+}


### PR DESCRIPTION
### Context

We want to more rapidly benchmark our Ruby versions using alternative build options, specifically using `jemalloc` instead of `malloc` for memory allocation. I originally forked this repository and stripped it down to get a work in progress. After successful experiments, I've decided to open this PR to extend the configuration options of the Ruby offerings in this repository.

### Approach

By adding three environment variables, we can enable multiple configurations of Ruby versions per OS. For example, we can build Ruby 2.5 on Ubuntu 16.04 with different build dependencies and Ruby configuration options. In this PR, I specifically add a `-jemalloc` flavor to Ruby v2.5 and v2.6 for most OS versions (a couple failed; see notes below).

- Add `RUBY_TAG_SUFFIX` env var to config.mk
  + Enables multiple name configurations per Ruby version per OS
  + e.g. `2.6-jemalloc`
- Add `RUBY_BUILD_DEPENDENCIES` env var to Dockerfile template
  + Enables multiple dependency settings per Ruby version per OS
  + e.g. any available apt package
- Add `RUBY_CONFIG_OPTS` env var to Dockerfile template
  + Enables multiple configuration settings per Ruby version per OS
  + e.g.`--with-jemalloc`
- Add `jemalloc` flavors for Ruby v2.5 & v2.6
  + Tested for Ruby 2.5.x & 2.6.x on all supported OS flavors
  + Failed for two, and thus they're not included
    * https://travis-ci.com/healthify/docker-ruby/builds/104499337
    * ubuntu 12.04
    * debian wheezy

### Misc. Changes

- Added EOL information about Ruby v2.4 in README as noted in [Ruby Maintenance Branches ](https://www.ruby-lang.org/en/downloads/branches/)
- Bumped Ruby v2.6 patch version to `2.6.3` in README