### PR TITLE
Version bump for 2.4

### DIFF
--- a/2.4/config.mk
+++ b/2.4/config.mk
@@ -1,6 +1,6 @@
 export RUBY_MAJOR_MINOR = 2.4
-export RUBY_PATCH = 8
+export RUBY_PATCH = 9
 
-export RUBY_SHA1SUM = a13b0915b7fb3dd0fe1ed6a4e3640034038ba6c9
+export RUBY_SHA1SUM = da07b802cf7598547f98b7b2d8fc8ff5f03dbef4
 
 export BUNDLER_VERSION = 2.0

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ for further information.
 * `2.1-ubuntu-16.04`   (aliased as `2.1`):   Ruby 2.1.10  (EOL March 31, 2017)
 * `2.2-ubuntu-16.04`   (aliased as `2.2`):   Ruby 2.2.10  (EOL March 31, 2018)
 * `2.3-ubuntu-16.04`   (aliased as `2.3`):   Ruby 2.3.8  (EOL March 31, 2019)
-* `2.4-ubuntu-16.04`   (aliased as `2.4`):   Ruby 2.4.8  (EOL March 31, 2020)
+* `2.4-ubuntu-16.04`   (aliased as `2.4`):   Ruby 2.4.9  (EOL March 31, 2020)
 * `2.5-ubuntu-16.04`   (aliased as `2.5`):   Ruby 2.5.7
 * `2.6-ubuntu-16.04`   (aliased as `2.6`):   Ruby 2.6.5
 


### PR DESCRIPTION
Ruby 2.4.8 tarball doesn't install: https://www.ruby-lang.org/en/news/2019/10/02/ruby-2-4-9-released/